### PR TITLE
Ajout de la correction des voies supra-communales et déplacement du fichier

### DIFF
--- a/documentation/avancee_des_corrections_de_la_base_voie.md
+++ b/documentation/avancee_des_corrections_de_la_base_voie.md
@@ -1,4 +1,4 @@
-# Corrections de la Base Voie réalisées au 11/10/2022 et à venir
+# Corrections de la Base Voie réalisées au 12/10/2022 et à venir
 
 ## Pour Litteralis
 
@@ -37,6 +37,7 @@ Ces modifications ont été réalisées pour cette application utilisée par la 
 
 - [ ] Affectation de leur latéralité aux voies administratives situées en limite de commune (en cours de préparation);
 - [ ] Homogénéisation de la nomenclature des noms de voie en suivant la règle de la BAL ;
+- [ ] Ajout d'une nouvelle relation supra-communale pour permettre de ne pas découper les voies métropolitaines/autoroutes par les communes qu'elles traversent ;
 - [ ] Tronçons affectés à une voie administrative située à plusieurs centaines de mètres ;
 - [ ] Voies secondaires affectées à deux voies principales (12 voies) ;
 - [ ] Voies en doubles filaires à l'intérieur des communes pour des voies de type AVENUE et BOULEVARD ;


### PR DESCRIPTION
## Modification :
- Ajout de la correction permettant de ne plus découper les voies métropolitaines/autoroutes par les communes qu'elles traversent en créant une nouvelle relation supra-communale (donc une nouvelle table dont la clé étrangère tapera sur TA_VOIE_ADMINISTRATIVE et disposant des identifiants côté voirie) ;

- Déplacement du fichier dans le dossier basevoie\documentation ;

### Actions à mener
- [x] un reviewer a été ajouté
- [x] le code et les noms d'objets suivent la [syntaxe](https://github.com/meldig/SQL/blob/master/doc/syntaxe.md)